### PR TITLE
add modification time support

### DIFF
--- a/pkg/sentry/fs/imgfs/fs.go
+++ b/pkg/sentry/fs/imgfs/fs.go
@@ -64,6 +64,7 @@ type fileMetadata struct {
 	End int64
 	Name string
 	Link string
+	ModTime int64
 	Type fileType
 }
 
@@ -157,9 +158,10 @@ func MountImgRecursive(ctx context.Context, msrc *fs.MountSource, metadata []fil
 		offsetEnd := metadata[*i].End
 		fileName := metadata[*i].Name
 		fileType := metadata[*i].Type
+		fileModTime := metadata[*i].ModTime
 
 		if fileType == ImgFSRegularFile {
-			inode, err := newInode(ctx, msrc, offsetBegin, offsetEnd, packageFD, mmap)
+			inode, err := newInode(ctx, msrc, offsetBegin, offsetEnd, fileModTime, packageFD, mmap)
 			if err != nil {
 				return nil, fmt.Errorf("can't create inode file %v, err: %v", fileName, err)
 			}

--- a/pkg/sentry/fs/imgfs/inode.go
+++ b/pkg/sentry/fs/imgfs/inode.go
@@ -256,9 +256,9 @@ func (f *fileInodeOperations) InvalidateUnsavable(ctx context.Context) error {
 }
 
 // newInode returns a new fs.Inode
-func newInode(ctx context.Context, msrc *fs.MountSource, begin int64, end int64, packageFD int, m []byte) (*fs.Inode, error) {
+func newInode(ctx context.Context, msrc *fs.MountSource, begin int64, end int64, modTime int64, packageFD int, m []byte) (*fs.Inode, error) {
 	sattr := stableAttr()
-	uattr := unstableAttr(ctx, begin, end)
+	uattr := unstableAttr(ctx, begin, end, modTime)
 	iops := &fileInodeOperations{
 		attr:     uattr,
 		mapArea:	m,

--- a/pkg/sentry/fs/imgfs/util.go
+++ b/pkg/sentry/fs/imgfs/util.go
@@ -39,15 +39,15 @@ func stableAttr() fs.StableAttr {
 	}
 }
 
-func unstableAttr(ctx context.Context, offsetBegin int64, offsetEnd int64) fs.UnstableAttr {
+func unstableAttr(ctx context.Context, offsetBegin int64, offsetEnd int64, unixTimens int64) fs.UnstableAttr {
 	return fs.UnstableAttr{
 		Size:             offsetEnd - offsetBegin,
 		Usage:            offsetEnd - offsetBegin,
 		Perms:            fs.FilePermsFromMode(0555),
 		Owner:            fs.FileOwnerFromContext(ctx),
-		AccessTime:       ktime.NowFromContext(ctx),
-		ModificationTime: ktime.NowFromContext(ctx),
-		StatusChangeTime: ktime.NowFromContext(ctx),
+		AccessTime:       ktime.FromNanoseconds(unixTimens),
+		ModificationTime: ktime.FromNanoseconds(unixTimens),
+		StatusChangeTime: ktime.FromNanoseconds(unixTimens),
 		Links:            1,
 	}
 }


### PR DESCRIPTION
Extra field in metadata: ModTime

I have confirmed that python reject the pycache because of the timestamp problem. I have injected detection code in CPython 3.7 version and with the support of modification time it won't recompile everything this time.

Please feel free to let me know if you have any suggestions & questions.

Two pull requests should be landed at the same time.
